### PR TITLE
fix discovered device creation

### DIFF
--- a/HiveMind_presence/devices.py
+++ b/HiveMind_presence/devices.py
@@ -7,7 +7,7 @@ class AbstractDevice:
     def __init__(self, host, port, device_type, ssl=False, name="HiveMind Node"):
         self.host = host
         self.port = port
-        self.ssl = ssl.lower() != "false" if not isinstance(ssl, bool) else ssl
+        self.ssl = ssl if isinstance(ssl, bool) else ssl.lower() != "false"
         self.device_type = device_type
         self.name = name
         self.uuid = str(uuid4())

--- a/HiveMind_presence/devices.py
+++ b/HiveMind_presence/devices.py
@@ -7,7 +7,7 @@ class AbstractDevice:
     def __init__(self, host, port, device_type, ssl=False, name="HiveMind Node"):
         self.host = host
         self.port = port
-        self.ssl = ssl
+        self.ssl = ssl.lower() != "false" if not isinstance(ssl, bool) else ssl
         self.device_type = device_type
         self.name = name
         self.uuid = str(uuid4())


### PR DESCRIPTION
Found this as i wondered why a SSL disabled discovery produced a wss [WebSocketApp](https://github.com/JarbasHiveMind/hivemind_websocket_client/blob/24c7cc00804fa7a00a514f10153b4358306c894e/hivemind_bus_client/client.py#L116)

uPNP/zeroconf dicoveries yield a string which irritates the subsequent procedures 