### PR TITLE
test: hivescope e2e + CI

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     with:
-      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
-      pre_install_pip: '"hivescope @ git+https://github.com/JarbasHiveMind/hivescope@dev"'
+      # 3.14 dropped: the [test] extra pulls the full hivemind-core 2.x stack
+      # for the hivescope e2e suite; align with hivemind-core's matrix.
+      python_versions: '["3.10", "3.11", "3.12", "3.13"]'
+      install_extras: 'test'
       test_path: 'tests/'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,5 +12,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'hivemind_presence'
       test_path: 'tests/'
-      pre_install_pip: '"hivescope @ git+https://github.com/JarbasHiveMind/hivescope@dev"'
+      install_extras: 'test'
       min_coverage: 0

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,7 @@
 """Top-level conftest.
 
-Loads hivescope's pytest plugin only when hivescope is importable, so unit/
-coverage workflows that don't install hivescope can still run without
-loading the e2e fixtures.
+hivescope ships the e2e fixtures and is a declared test dependency
+(the [test] extra) — loaded unconditionally so a missing install fails
+loudly instead of silently skipping the e2e suite.
 """
-try:
-    import hivescope  # noqa: F401
-    pytest_plugins = ["hivescope.pytest_fixtures"]
-except ImportError:
-    pass
+pytest_plugins = ["hivescope.pytest_fixtures"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,17 @@ dependencies = [
     "rich",
 ]
 
+[project.optional-dependencies]
+# The e2e suite (tests/e2e/) drives connection-presence through an in-process
+# hivescope hive. hivescope is published; the prerelease floor below lets a
+# plain `pip install .[test]` resolve the 2.x hivemind stack with no --pre
+# (PEP 440: a prerelease floor opts that package into prereleases).
+test = [
+    "pytest",
+    "hivescope>=0.5.2a1",
+    "ovos-bus-client>=2.0.0a3,<3.0.0",
+]
+
 [project.scripts]
 hivemind-presence = "hivemind_presence.scripts:hmpresence_cmds"
 

--- a/tests/e2e/test_presence.py
+++ b/tests/e2e/test_presence.py
@@ -1,6 +1,5 @@
 """E2E tests for HiveMind presence tracking."""
 
-from hivescope import TopologyBuilder
 from hivescope.scenarios import three_satellites
 from hivescope.assertions import assert_client_registered
 


### PR DESCRIPTION
## What

Moves the hivescope e2e dependency from a CI git pin to the package metadata.

- `pyproject.toml`: new `[test]` extra — `pytest`, `hivescope>=0.5.2a1` and an `ovos-bus-client` 2.x prerelease floor so a plain `pip install .[test]` resolves with no `--pre` and no git pins.
- `.github/workflows/build-tests.yml` + `coverage.yml`: drop the `pre_install_pip` git install of hivescope; install the `test` extra instead. Build matrix aligned with hivemind-core (3.10–3.13) since the extra pulls that stack.
- `conftest.py`: loads `hivescope.pytest_fixtures` unconditionally — hivescope is now a declared test dep, so a missing install fails loudly instead of silently skipping the e2e suite.
- `tests/e2e/test_presence.py`: drop an unused import (ruff F401).

## What the e2e exercises

`tests/e2e/` (already on dev) drives connection-presence through an in-process hivescope hive: satellites connecting are tracked in `connected_peers()` / registered clients, and disconnects clear presence on the master.

## Honest scope note

**hivemind-presence has limited hivescope surface.** This package's core job — UPnP/zeroconf LAN discovery and announcement — is out-of-band of hive message routing, which is what hivescope simulates. The e2e here covers the hub-side connection-presence semantics only; the LAN discovery protocol itself is not (and cannot meaningfully be) exercised by a hivescope topology. No stub tests were added to fake broader coverage.

## Verified

Fresh venv, `pip install -e .[test]`, `pytest tests/`: 4 passed. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)