### PR TITLE
test: real zeroconf advertise<->discover e2e (LAN discovery coverage)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ test = [
     "pytest",
     "hivescope>=0.5.2a1",
     "ovos-bus-client>=2.0.0a3,<3.0.0",
+    # zeroconf drives the real advertise<->discover e2e (tests/e2e/test_discovery.py);
+    # it is an optional (LGPL) transport for end users but required to exercise it.
+    "zeroconf",
 ]
 
 [project.scripts]

--- a/tests/e2e/test_discovery.py
+++ b/tests/e2e/test_discovery.py
@@ -1,0 +1,107 @@
+"""Real LAN advertise <-> discover end-to-end tests.
+
+Unlike ``test_presence.py`` (which drives connection-presence through an
+in-process hivescope hive), these tests exercise this package's own reason to
+exist: a node advertises itself on the local network and a second, independent
+discovery client finds it and reads back the announced connection parameters.
+
+The zeroconf/mDNS exchange is real — two independent ``Zeroconf`` stacks talk
+over the loopback/LAN multicast group; nothing is mocked. The UPnP/SSDP variant
+is marked SKIP because it relies on an ``M-SEARCH`` multicast round-trip that is
+unreliable (and frequently blocks) inside sandboxed CI runners.
+"""
+import time
+
+import pytest
+
+# zeroconf is an optional (LGPL) transport for end users, but the [test] extra
+# installs it so this real advertise<->discover suite always runs in CI.
+import zeroconf  # noqa: F401
+
+from hivemind_presence.presence import LocalPresence
+from hivemind_presence.discovery import LocalDiscovery
+
+
+def _wait_for_node(discovery, timeout=20):
+    """Block until the discovery client sees at least one node, or time out."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if discovery.nodes:
+            return True
+        time.sleep(0.2)
+    return False
+
+
+def test_zeroconf_advertise_then_discover():
+    """A LocalPresence advertises over zeroconf; an independent LocalDiscovery
+    finds it and reads back the announced host/port/name."""
+    port = 5678
+    name = "E2E-Zeroconf-Node"
+
+    presence = LocalPresence(port=port, name=name, upnp=False, zeroconf=True)
+    if presence.zero is None:
+        pytest.skip("zeroconf transport unavailable in this environment")
+
+    discovery = LocalDiscovery(upnp=False, zeroconf=True)
+    found = []
+    discovery.on_new_node = lambda node: found.append(node)
+
+    try:
+        presence.start()
+        discovery.start()
+        assert _wait_for_node(discovery), (
+            "discovery client never saw the advertised zeroconf node"
+        )
+    finally:
+        discovery.stop()
+        presence.stop()
+
+    assert found, "on_new_node callback was never fired"
+    node = found[0]
+    # the announced connection parameters survived the real mDNS round-trip
+    assert node.friendly_name == name
+    assert node.port == port
+    assert node.host  # a concrete advertised address, not empty
+    assert node.address == f"{node.host}:{port}"
+
+
+def test_zeroconf_service_type_filtering():
+    """A discovery client scanning for a different service_type must NOT pick up
+    a node advertised under the default HiveMind service_type."""
+    presence = LocalPresence(port=5679, name="Typed-Node",
+                             service_type="HiveMind-websocket",
+                             upnp=False, zeroconf=True)
+    if presence.zero is None:
+        pytest.skip("zeroconf transport unavailable in this environment")
+
+    discovery = LocalDiscovery(upnp=False, zeroconf=True,
+                               service_type="SomeOtherService")
+    try:
+        presence.start()
+        discovery.start()
+        # give the exchange ample time; we expect to find NOTHING
+        assert not _wait_for_node(discovery, timeout=6), (
+            "discovery matched a node under the wrong service_type"
+        )
+    finally:
+        discovery.stop()
+        presence.stop()
+
+
+@pytest.mark.skip(
+    reason="UPnP/SSDP discovery needs an M-SEARCH multicast round-trip that is "
+           "unreliable and often blocks inside sandboxed CI runners; the zeroconf "
+           "path above provides the real advertise<->discover coverage."
+)
+def test_upnp_advertise_then_discover():
+    """Placeholder documenting the intended UPnP/SSDP e2e (see skip reason)."""
+    presence = LocalPresence(port=5678, name="E2E-UPnP-Node",
+                             upnp=True, zeroconf=False)
+    discovery = LocalDiscovery(upnp=True, zeroconf=False)
+    try:
+        presence.start()
+        discovery.start()
+        assert _wait_for_node(discovery, timeout=30)
+    finally:
+        discovery.stop()
+        presence.stop()

--- a/tests/unit/test_construction.py
+++ b/tests/unit/test_construction.py
@@ -1,0 +1,37 @@
+"""Unit coverage for LocalPresence / LocalDiscovery transport wiring.
+
+These exercise the object graph without any network exchange, so they run fast
+and without the hivescope hive or a live LAN.
+"""
+import pytest
+
+from hivemind_presence.presence import LocalPresence
+from hivemind_presence.discovery import LocalDiscovery
+
+
+def test_presence_zeroconf_only_has_no_upnp():
+    p = LocalPresence(upnp=False, zeroconf=True)
+    assert p.upnp is None
+    assert p.zero is not None  # zeroconf installed via [test]
+
+
+def test_presence_upnp_only_has_no_zeroconf_announce():
+    p = LocalPresence(upnp=True, zeroconf=False)
+    assert p.upnp is not None
+    assert p.zero is None
+
+
+def test_discovery_zeroconf_only_has_no_upnp():
+    d = LocalDiscovery(upnp=False, zeroconf=True)
+    assert d.upnp is None
+    assert d.zero is not None
+
+
+def test_discovery_requires_at_least_one_transport():
+    with pytest.raises(ValueError):
+        LocalDiscovery(upnp=False, zeroconf=False)
+
+
+def test_discovery_nodes_starts_empty():
+    d = LocalDiscovery(upnp=False, zeroconf=True)
+    assert d.nodes == {}


### PR DESCRIPTION
## What

Adds genuine end-to-end coverage for the thing this package actually exists to do — advertise a node on the LAN and discover it — which was previously **untested**.

### The gap
`tests/e2e/test_presence.py` / `test_disconnect.py` drive *connection*-presence (a master's `connected_peers()`) through an in-process hivescope hive. Useful, but they exercise **hivemind-core**, not this package: no test touched `zero.py`/`ssdp.py`/`upnp_server.py` advertise/discover.

### Added
- `tests/e2e/test_discovery.py` — a `LocalPresence` advertises over zeroconf; an **independent** `LocalDiscovery` finds it and reads back the announced host/port/name. Real mDNS round-trip across two `Zeroconf` stacks, **no mocks**. Plus a `service_type` negative-filter test.
- UPnP/SSDP e2e is present but **`@pytest.mark.skip`** — its `M-SEARCH` multicast round-trip is unreliable and frequently blocks inside sandboxed CI runners. Verified live locally: zeroconf discovers in <1s; the UPnP scan hangs. The skip reason states this precisely.
- `tests/unit/test_construction.py` — transport-toggle unit tests (TODO flagged none existed).
- `zeroconf` added to the `[test]` extra so the real path always runs in CI (it stays an optional LGPL transport for end users).

## Evidence
Full suite locally: **11 passed, 1 skipped** (2 new zeroconf e2e + 5 unit + 4 pre-existing hivescope e2e). The zeroconf exchange genuinely round-trips the announced params.

## Not in scope
UPnP/SSDP live coverage (blocked in CI); GGWave/beacon (handled separately in hivemind-core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)