### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ without being told its IP address, and a satellite **scans** the LAN to discover
 reachable hubs.
 
 It sits next to [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core)
-(the hub) and the client libraries: the hub advertises its WebSocket address with
-`hivemind-presence announce`, and a client uses `hivemind-presence scan` (or the
+(the hub) and the client libraries. The hub advertises its WebSocket address with
+`hivemind-presence announce`. A client uses `hivemind-presence scan` (or the
 `LocalDiscovery` API) to locate it and open a connection.
 
 ## Discovery transports
 
-- **mDNS / Zeroconf** — multicast DNS service discovery. Optional dependency
-  (`zeroconf` is LGPL and imported lazily); install it to enable mDNS.
-- **UPnP / SSDP** — an SSDP server advertises a UPnP device descriptor; the
+- **mDNS / Zeroconf**: multicast DNS service discovery. The optional
+  `zeroconf` dependency is LGPL and imported lazily. Install it to enable mDNS.
+- **UPnP / SSDP**: an SSDP server advertises a UPnP device descriptor. The
   scanner discovers it over SSDP.
 
-The roadmap moves the default to **HiveBeacon** — a zero-dependency UDP broadcast
-beacon absorbed from the archived `HiveBeacon` project — with mDNS kept as an
-optional transport. UPnP is being retired. Until the beacon transport ships, mDNS
-and UPnP are the available transports.
+The roadmap moves the default transport to **HiveBeacon**, a zero-dependency UDP
+broadcast beacon absorbed from the archived `HiveBeacon` project, and keeps mDNS
+as an optional transport. UPnP is being retired. Until the beacon transport
+ships, mDNS and UPnP are the available transports.
 
 ## Prerequisites
 
@@ -117,17 +117,17 @@ discovered hub.
 | `--upnp` | `false` | Use the UPnP/SSDP transport. |
 | `--ssl` | `false` | Advertise SSL support (announce only). |
 
-At least one transport must be enabled for `scan`; `LocalDiscovery` raises if both
-are disabled.
+At least one transport must be enabled for `scan`. `LocalDiscovery` raises an
+error if both are disabled.
 
 ## Documentation
 
 See [`docs/`](docs/index.md):
 
-- [How it works](docs/how-it-works.md) — announce/scan flow and the transports.
-- [Configuration reference](docs/configuration.md) — every CLI option and API
+- [How it works](docs/how-it-works.md): the announce/scan flow and the transports.
+- [Configuration reference](docs/configuration.md): every CLI option and API
   argument.
-- [Examples](docs/examples.md) — discover-then-connect, hub announce loop.
+- [Examples](docs/examples.md): discover-then-connect, hub announce loop.
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ Advertise this node on the LAN.
 | --- | --- | --- | --- |
 | `--port` | int | `5678` | HiveMind WebSocket port to advertise. |
 | `--name` | str | `HiveMind-Node` | Friendly device name shown to scanners. |
-| `--service-type` | str | `HiveMind-websocket` | Service identifier; must match the scanner's value. |
+| `--service-type` | str | `HiveMind-websocket` | Service identifier. Must match the scanner's value. |
 | `--zeroconf` | bool | `true` | Advertise via mDNS/Zeroconf. |
 | `--upnp` | bool | `false` | Advertise via UPnP/SSDP. |
 | `--ssl` | bool | `false` | Report SSL support (scanners connect with `wss://`). |
@@ -61,10 +61,10 @@ Raises `ValueError` if both transports are disabled.
 
 Key members:
 
-- `on_new_node(node)` — assign a callback to react to each discovered node.
-- `scan(timeout=25)` — generator yielding each newly discovered `HiveMindNode`
-  once, until `timeout` seconds elapse.
-- `nodes` — dict of `host:port` → `HiveMindNode` seen so far.
+- `on_new_node(node)`: assign a callback to react to each discovered node.
+- `scan(timeout=25)`: a generator that yields each newly discovered
+  `HiveMindNode` once, until `timeout` seconds elapse.
+- `nodes`: a dict of `host:port` to `HiveMindNode`, for nodes seen so far.
 - `start()` / `stop()`.
 
 ### `HiveMindNode`
@@ -79,3 +79,6 @@ HiveMindNode.connect(key, crypto_key=None, self_signed=True,
 
 Opens a `HiveMessageBusClient` to the node (`wss://` if the node advertised SSL,
 else `ws://`), runs it in a thread, and returns the bus.
+
+---
+[← How it works](how-it-works.md) · [Home](index.md) · [Examples →](examples.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -63,3 +63,6 @@ disc.stop()
 hivemind-presence announce --name kitchen --upnp true
 hivemind-presence scan --upnp true
 ```
+
+---
+[← Configuration](configuration.md) · [Home](index.md)

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -8,10 +8,10 @@ on a satellite or any client that needs to find a hub).
 `LocalPresence` (CLI: `hivemind-presence announce`) starts an advertiser for each
 enabled transport:
 
-- **mDNS** — `ZeroConfAnnounce` registers a Zeroconf service of type
+- **mDNS**: `ZeroConfAnnounce` registers a Zeroconf service of type
   `--service-type` (default `HiveMind-websocket`) carrying the node name, host,
-  port and SSL flag.
-- **UPnP** — `UPNPAnnounce` runs an SSDP server plus a small HTTP server that
+  port, and SSL flag.
+- **UPnP**: `UPNPAnnounce` runs an SSDP server plus a small HTTP server that
   serves a UPnP device descriptor (and SCPD XML) describing the node.
 
 The advertised record contains everything a client needs to connect: friendly
@@ -42,14 +42,18 @@ once, until the timeout elapses.
 ## Connecting
 
 `HiveMindNode.connect(key, crypto_key=None, self_signed=True)` builds a
-`HiveMessageBusClient` for the discovered node — `wss://` when the node advertised
-SSL, otherwise `ws://` — runs it in a thread, and returns the live bus. The access
-key and crypto key are the node's HiveMind credentials; presence does not handle
-authentication, only locating the address to connect to.
+`HiveMessageBusClient` for the discovered node. It uses `wss://` when the node
+advertised SSL, otherwise `ws://`. It runs the client in a thread and returns the
+live bus. The access key and crypto key are the node's HiveMind credentials.
+Presence does not handle authentication, only locating the address to connect
+to.
 
 ## Optional dependency behaviour
 
 The `zeroconf` package is LGPL and imported lazily. If it is not installed,
 `_init_zeroconf` swallows the `ImportError` and disables the mDNS transport. With
 mDNS disabled and `--upnp false`, `LocalDiscovery` raises `ValueError` because no
-transport is active — enable UPnP or install `zeroconf`.
+transport is active. Enable UPnP or install `zeroconf`.
+
+---
+[Home](index.md) · [Configuration →](configuration.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # HiveMind-presence
 
 Local-network presence and discovery for HiveMind nodes. A hub announces itself
-so satellites can find it without a hardcoded address; a satellite scans the LAN
+so satellites can find it without a hardcoded address. A satellite scans the LAN
 to discover reachable hubs and open a connection.
 
 - [How it works](how-it-works.md)
@@ -12,7 +12,7 @@ to discover reachable hubs and open a connection.
 
 HiveMind-presence is the discovery layer of the
 [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) mesh. It does not move
-protocol traffic itself — it advertises and locates the WebSocket address of a
+protocol traffic itself. It advertises and locates the WebSocket address of a
 [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) hub. Once a node
 is discovered, the matching client (Python `hivemind-bus-client`, browser, ESP32)
 opens the encrypted HiveMind connection.
@@ -23,4 +23,4 @@ opens the encrypted HiveMind connection.
 | --- | --- | --- |
 | mDNS / Zeroconf | available, default | Optional `zeroconf` dependency (LGPL). |
 | UPnP / SSDP | available, opt-in | Enable with `--upnp true`. |
-| HiveBeacon (UDP broadcast) | planned default | Zero-dependency broadcast beacon, becomes the default; mDNS stays optional. |
+| HiveBeacon (UDP broadcast) | planned default | Zero-dependency broadcast beacon. Becomes the default. mDNS stays optional. |


### PR DESCRIPTION
Rewrites the README and the docs/ pages for clarity, removing semicolons, em dashes, and overlong sentences while keeping every fact, code block, and link. Adds the navigation footer convention across the docs/ set (how-it-works, configuration, examples), linked from the existing index.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified discovery transport guidance, including HiveBeacon, optional mDNS, and retiring UPnP.
  * Updated service type and local discovery configuration descriptions.
  * Improved wording, formatting, punctuation, and optional dependency guidance.
  * Added navigation links between documentation pages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->