### PR TITLE
fix: LocalPresence defaults SSDP/UPnP off per DISCOVERY-1 §2.2

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ Discover nodes on the LAN and print them in a table.
 
 ```python
 LocalPresence(port=5678, ssl=False, service_type="HiveMind-websocket",
-              name="HiveMind-Node", upnp=True, zeroconf=True)
+              name="HiveMind-Node", upnp=False, zeroconf=True)
 ```
 
 | Argument | Default | Description |
@@ -40,7 +40,7 @@ LocalPresence(port=5678, ssl=False, service_type="HiveMind-websocket",
 | `ssl` | `False` | Advertise SSL support. |
 | `service_type` | `HiveMind-websocket` | Service identifier. |
 | `name` | `HiveMind-Node` | Friendly device name. |
-| `upnp` | `True` | Enable the UPnP transport. |
+| `upnp` | `False` | Enable the UPnP transport. |
 | `zeroconf` | `True` | Enable the mDNS transport (no-op if `zeroconf` is not installed). |
 
 Methods: `start()`, `stop()`.

--- a/hivemind_presence/presence.py
+++ b/hivemind_presence/presence.py
@@ -4,7 +4,7 @@ from hivemind_presence.upnp_server import UPNPAnnounce
 class LocalPresence:
     def __init__(self, port=5678, ssl=False,
                  service_type="HiveMind-websocket",
-                 name="HiveMind-Node", upnp=True, zeroconf=True):
+                 name="HiveMind-Node", upnp=False, zeroconf=True):
         self._nodes = {}
         self.upnp = None
         self.zero = None

--- a/tests/unit/test_construction.py
+++ b/tests/unit/test_construction.py
@@ -9,6 +9,11 @@ from hivemind_presence.presence import LocalPresence
 from hivemind_presence.discovery import LocalDiscovery
 
 
+def test_presence_defaults_to_no_upnp():
+    p = LocalPresence()
+    assert p.upnp is None
+
+
 def test_presence_zeroconf_only_has_no_upnp():
     p = LocalPresence(upnp=False, zeroconf=True)
     assert p.upnp is None


### PR DESCRIPTION
## Summary
- `LocalPresence.__init__` defaulted `upnp=True`, so any direct caller (bypassing hivemind-core, which always passes an explicit `upnp=False`) broadcast over SSDP unasked. DISCOVERY-1 §2.2 requires SSDP off by default.
- Verified §2.2 against origin/dev source before treating it as ground truth: `hivemind-core/hivemind_core/service.py` and `hm-core-v3/hivemind_core/service.py` both already pass explicit `upnp=presence_cfg.get("upnp", False)`, so the server itself was never affected — only direct library callers.
- CLI (`scripts.py`) and `docs/configuration.md`'s CLI table already documented `--upnp` default `False`; only the `LocalPresence` constructor default and its API-doc code sample were stale — both fixed.
- This resolves the strict xfail `test_presence_library_also_defaults_ssdp_off` recorded in hivemind-test-harness PR #22.

## Test plan
- [x] Added `test_presence_defaults_to_no_upnp` asserting `LocalPresence().upnp is None`
- [x] `~/.venvs/ovos/bin/python -m pytest tests -q -p no:ovoscope -p no:recording --timeout=600` — 12 passed, 1 skipped