### PR TITLE
fix(ci): stop passing a bare extras name as pip arguments

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,5 +12,12 @@ jobs:
       python_version: '3.11'
       coverage_source: 'hivemind_presence'
       test_path: 'tests/'
-      install_extras: 'test'
+      # Name the extra explicitly. `install_extras` is a list of pip
+      # *arguments*, so passing a bare 'test' there ran `pip install test`
+      # and looked for a PyPI package by that name. `test_extras` is the
+      # extras key, which is what this repo actually needs: the default
+      # PRIMARY of 'dev' does not exist here, and `pip install -e .[dev]`
+      # succeeds anyway on an unknown extra, so the workflow never fell
+      # back to [test] and pytest ran without hivescope.
+      test_extras: 'test'
       min_coverage: 0


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Coverage has been red on every PR in this repo. Two faults stacked:

**1. `install_extras: 'test'`** — that input is a list of pip *arguments*, not an extras key, so the shared workflow ran `uv pip install test` and looked for a PyPI package named "test".
Verified in [run 30861545981](https://github.com/JarbasHiveMind/HiveMind-presence/actions/runs/30861545981): `No solution found ... there are no versions of test`.

**2. Removing it is not enough.** The workflow's first attempt is `pip install -e .[dev]`, and this repo declares only a `test` extra — but pip exits 0 on an unknown extra, so that attempt "succeeded" and the `[test]` fallback never ran.
Verified in [run 31386134506](https://github.com/JarbasHiveMind/HiveMind-presence/actions/runs/31386134506) (this branch, first attempt): install passed, then `ImportError: Error importing plugin \"hivescope.pytest_fixtures\": No module named 'hivescope'`.

Fix: name the extra that exists — `test_extras: 'test'`.

Note the second fault is a latent trap for any repo that leaves `test_extras` unset without declaring a `dev` extra: the install silently skips test dependencies instead of failing.

Unblocks #17, which is in turn a prerequisite for hivemind-test-harness#22 (its DISCOVERY-1 §2.2 xfail cannot flip to a real assertion until a presence release carries `upnp=False`).